### PR TITLE
Android - Fix Drawable v4 paths in Android Artifact Resources (Librar…

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -21,6 +21,7 @@ void runBefore(String dependentTaskName, Task task) {
 }
 
 gradle.projectsEvaluated {
+    def isAndroidLibrary = plugins.hasPlugin("com.android.library")
     // Grab all build types and product flavors
     def buildTypes = android.buildTypes.collect { type -> type.name }
     def productFlavors = android.productFlavors.collect { flavor -> flavor.name }
@@ -88,6 +89,24 @@ gradle.projectsEvaluated {
                 enabled config."bundleIn${targetName}" ||
                     config."bundleIn${buildTypeName.capitalize()}" ?:
                             targetName.toLowerCase().contains("release")
+
+                if (isAndroidLibrary) {
+                    doLast {
+                        def moveFunc = { resSuffix ->
+                            File originalDir = file("${resourcesDir}/drawable-${resSuffix}")
+                            if (originalDir.exists()) {
+                                File destDir = file("${resourcesDir}/drawable-${resSuffix}-v4")
+                                ant.move(file: originalDir, tofile: destDir)
+                            }
+                        }
+                        moveFunc.curry("ldpi").call()
+                        moveFunc.curry("mdpi").call()
+                        moveFunc.curry("hdpi").call()
+                        moveFunc.curry("xhdpi").call()
+                        moveFunc.curry("xxhdpi").call()
+                        moveFunc.curry("xxxhdpi").call()
+                    }
+                }
             }
 
             // Hook bundle${productFlavor}${buildType}JsAndAssets into the android build process


### PR DESCRIPTION
## Motivation (required)

```
Unknown source file : /home/tom/projects/blueprint-native/android/app/build/intermediates/res/merged/release/drawable-mdpi-v4/images_google.png: error: Duplicate file.

Unknown source file : /home/tom/projects/blueprint-native/android/app/build/intermediates/res/merged/release/drawable-mdpi/images_google.png: Original is here. The version qualifier may be implied.
```

We've been attempting to package our React Native code into Library Dependencies (Cocoapods / Android Artifact Resource (aar)). Recently in React Native 0.42.0, there was an upgrade to the Android Project's gradle plugin from 1.3.1 to 2.2.3. This update drastically effected the outcome of drawable resources in Android without anyone noticing.

#### There are 4 outcomes to consider with this change:

1. You are developing in an Android Application using Gradle 1.3.1 or lower
2. You are developing in an Android Application using Gradle 2.2.3 or higher
3. You are developing in an Android Library Module using Gradle 1.3.1 or lower
4. You are developing in an Android Library Module using Gradle 2.2.3 or higher

With the upgrade to 2.2.3, Android changed the way aapt builds its resources. Any Library created with 2.2.3, has its resources ending with a `v4` suffix. The reasoning behind this I'm not sure of but assume it deals with Vector support that was added around that time.

The change I've added checks if React Native is being ran in an Android Library vs an Application, and appends the v4 suffix to the merged asset folders.

## Test Plan (required)

Multiple test were performed.

1. I first started out validating my assumption about the asset merger by creating a new Android Project to verify my assumptions above.

      i. Application + >= 2.2.3 -- hdpi contains my drawable. hdpi-v4 contains dependency's drawables.
      ii. Application + <= 1.3.1 -- Same as above (I expect because deps are compiled against gradle 2.2.3+ themselves.
      iii. Library + >= 2.2.3 -- Only -v4 folders found! Resources from the library are packages in the app's build output in similar -v4 folder too.
      iv. Library + <= 1.3.1 -- Same as ii. & iii. -v4 contains other resources, but my resources are located in non -v4 folder.

2. I then wanted to validate against React Native itself. So I updated my react native code using this PR/Branch, and tested against my project locally. Unfortunately I cannot share that code as it is private, but before this change I was getting the same error as mentioned in #5787 and now my build runs as intended with the assets being placed where they should be.

Additional resources:

http://stackoverflow.com/questions/35700272/android-build-tool-adds-v4-qualifier-to-drawable-folders-by-default-in-generated