### PR TITLE
Change indentation of package.json including Jest to 2 spaces

### DIFF
--- a/local-cli/init/init.js
+++ b/local-cli/init/init.js
@@ -113,7 +113,7 @@ function addJestToPackageJson(destinationRoot) {
   packageJSON.jest = {
     preset: 'react-native'
   };
-  fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, '\t'));
+  fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2));
 }
 
 module.exports = init;


### PR DESCRIPTION
## Motivation (required)

Indentation of package.json including Jest is a hard tab. Since package.json generated by npm has two spaces, I want to make it the same.

## Test Plan (required)

![image](https://user-images.githubusercontent.com/869489/28476940-d37ac4ee-6e06-11e7-90dd-024313c7316d.png)
